### PR TITLE
numeric input fix

### DIFF
--- a/content_scripts/tv.js
+++ b/content_scripts/tv.js
@@ -137,10 +137,9 @@ tv.getStrategy = async (strategyName = null, isIndicatorSave = false) => {
         i++
         if (indicProperties[i] && indicProperties[i].querySelector('input')) {
           let propValue = indicProperties[i].querySelector('input').value
-          if(indicProperties[i].querySelector('input').getAttribute('inputmode') === 'numeric' ||
-            (parseFloat(propValue) == propValue || parseInt(propValue) == propValue)) { // not only inputmode==numbers input have digits
-            const digPropValue = parseFloat(propValue) == parseInt(propValue) ? parseInt(propValue) : parseFloat(propValue)  // TODO how to get float from param or just search point in string
-            if(!isNaN(propValue))
+          if(indicProperties[i].querySelector('input').getAttribute('inputmode') === 'numeric') { 
+            const digPropValue = parseFloat(propValue.replace(' ',''))  // tradingview sometimes adds a space as thousand separator
+            if(!isNaN(digPropValue)){
               strategyData.properties[propText] = digPropValue
             else
               strategyData.properties[propText] = propValue

--- a/content_scripts/tv.js
+++ b/content_scripts/tv.js
@@ -141,8 +141,9 @@ tv.getStrategy = async (strategyName = null, isIndicatorSave = false) => {
             const digPropValue = parseFloat(propValue.replace(' ',''))  // tradingview sometimes adds a space as thousand separator
             if(!isNaN(digPropValue)){
               strategyData.properties[propText] = digPropValue
-            else
+            }else{
               strategyData.properties[propText] = propValue
+            }
           } else {
             strategyData.properties[propText] = propValue
           }


### PR DESCRIPTION
There is no way to discern whether a numeric input is a pine float or integer.  It is left to the user to enter the correct stepping for tests.

Also with pine input type of "int", tradingview ui uses a space as a thousand separator which javascript would fail to parse as a number.

This pull request fixes both issues.