### PR TITLE
Download "List of trades"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # About
 This tool builds upon two existing Chrome Extensions for backtesting in Tradingview:
 
-[The optimizer] https://chrome.google.com/webstore/detail/the-optimiser-tradingview/emcpjechgmpcnjphefjekmdlaljbiegp
+[The optimizer] (https://chrome.google.com/webstore/detail/the-optimiser-tradingview/emcpjechgmpcnjphefjekmdlaljbiegp)
 
 and The
-[Tradingview assistant] https://chrome.google.com/webstore/detail/tradingview-assistant/pfbdfjaonemppanfnlmliafffahlohfg
+[Tradingview assistant] (https://chrome.google.com/webstore/detail/tradingview-assistant/pfbdfjaonemppanfnlmliafffahlohfg).
 
-I am not certain about their history, but for the most part the codes are identical. Going over their online history, The Tradingview Assistant is older by a couple days, and has made the code open source in Github.
+I am not certain about their history, but for the most part the codes are identical. Going over their online history, The Tradingview Assistant is older by a couple days, and has made the code open source in [Github] (https://github.com/akumidv/tradingview-assistant-chrome-extension).
 
 Unfortuntely, they both lack the functionaility to download the List of Trades of each iteraction of the optimization, which can be used for different reasons. That fucntionaility is created here. To do so, six of the original files from The Tradingview Assistant were created or modified:
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # About
 This tool builds upon two existing Chrome Extensions for backtesting in Tradingview:
 
-[The optimizer] (https://chrome.google.com/webstore/detail/the-optimiser-tradingview/emcpjechgmpcnjphefjekmdlaljbiegp)
+[The optimizer](https://chrome.google.com/webstore/detail/the-optimiser-tradingview/emcpjechgmpcnjphefjekmdlaljbiegp)
 
 and The
-[Tradingview assistant] (https://chrome.google.com/webstore/detail/tradingview-assistant/pfbdfjaonemppanfnlmliafffahlohfg).
+[Tradingview assistant](https://chrome.google.com/webstore/detail/tradingview-assistant/pfbdfjaonemppanfnlmliafffahlohfg).
 
-I am not certain about their history, but for the most part the codes are identical. Going over their online history, The Tradingview Assistant is older by a couple days, and has made the code open source in [Github] (https://github.com/akumidv/tradingview-assistant-chrome-extension).
+I am not certain about their history, but for the most part the codes are identical. Going over their online history, The Tradingview Assistant is older by a couple days, and has made the code open source in [Github](https://github.com/akumidv/tradingview-assistant-chrome-extension).
 
 Unfortuntely, they both lack the functionaility to download the List of Trades of each iteraction of the optimization, which can be used for different reasons. That fucntionaility is created here. To do so, six of the original files from The Tradingview Assistant were created or modified:
 

--- a/README.md
+++ b/README.md
@@ -1,173 +1,30 @@
 # About
-An assistant for backtesting trading strategies and checking (showing) external signals in Tradingview implemented as a Chrome browser extension.
+This tool builds upon two existing Chrome Extensions for backtesting in Tradingview:
 
-Add to Chrome from [webstore](https://chrome.google.com/webstore/detail/tradingview-assistant/pfbdfjaonemppanfnlmliafffahlohfg)
+[The optimizer] https://chrome.google.com/webstore/detail/the-optimiser-tradingview/emcpjechgmpcnjphefjekmdlaljbiegp
 
-[Watch the youtube video](https://youtu.be/xhnlSCIlEkw)
+and The
+[Tradingview assistant] https://chrome.google.com/webstore/detail/tradingview-assistant/pfbdfjaonemppanfnlmliafffahlohfg
 
-Video [how to install extension](https://www.youtube.com/watch?v=FH7dI4K8w5k)
+I am not certain about their history, but for the most part the codes are identical. Going over their online history, The Tradingview Assistant is older by a couple days, and has made the code open source in Github.
 
-## Declaimer
-**Attention!** 
+Unfortuntely, they both lack the functionaility to download the List of Trades of each iteraction of the optimization, which can be used for different reasons. That fucntionaility is created here. To do so, six of the original files from The Tradingview Assistant were created or modified:
 
-Active use of the extension can cause detection by the TradingView as using a bot for backtesting and lead to the ban of the user's account.
+From root folder:
+  1. background.js
+  2. manifest.json
 
-Although the extension is not a bot (i.e. it does not work independently of the user in the cloud), it does not use the 
-TradingView API and does not interfere with data transmission, but only automates user behavior through the UI. Its use and 
-all risks remain with the users. 
+From Content_Scripts folder:
+  1. action.js
+  2. backtest.js
+  3. file.js
+  4. tv.js
 
-**Disclaimer** 
+You can simply copy those files from this repository and replace them in the original extension.
 
-The developer of the extension does not response for any possible consequences of its use.
+To install from here:
 
-
-## Last version changes
-2.1 => 2.2:
-- fix for TV UI changes
-- fix for breaking set of strategy parameters if strategy have parameters with identical names
-
-2.0 => 2.1
-- fixed TV UI changed in performance report table that freeze extension
-
-1.16 => 2.0(1.17):
-- deep backtesting - thanks @Murena7 for implementation draft version 
-- fixed for chrome memory error (increased possible cycles for backtesting and speed for settiings of parameters)
-- delay for backtesting results (for deep backtesting x2)
-- delay between backtests for reduce TV API load
-- saving in CSV values with more than 2 digits after point
-- fixes for numbers input in nonumbers fields - thanks @TomKaltz for pull request with changes
-- backtesting for timeframes - thanks jarno for suppport this changes in version
-
-
-## Functionality
-
-
-### Backtesting trading strategies, optimisation of the strategy's parameters:
-
-![](docs/Screenshot1.png)
-
-* automatic getting a list of parameters and their types (numeric, lists and checkboxes are supported)
-* generation of the testing range according to the rule: the beginning value is 2 times less than the current one, the end is 2 times more than the current one.
-* saving the generated parameters of testing a trading strategy for their correction as a template in a file in CSV format
-* Loading adjusted parameter ranges from a CSV file
-* Configuring the optimisation model:
-    * Choosing the type of optimisation: searching for the maximum or minimum values
-    * Selecting an optimised value from the entire list of strategy results in Tradingview (Net Profit, Ratio Avg Win / Avg Loss, Sharpe Ratio, Sortino Ratio, etc.)
-    * Choosing a search strategy in the parameter space(random, sequential, annealing method)
-* Filtering of unsuitable results. For example, the number of tradings is less than necessary
-* Setting the number of cycles to search for parameters.
-* Performing automatic selection of parameters with storing all the results in the browser storage and the ability to save them as CSV files after testing, including in case of an error or page reloading
-* Showing backtesting results on 3d chartto analyze the effect of various parameters on the result.
-![](docs/Screenshot3.png)
-
-#### Optimization Methods
-The **sequential improvements** optimization method is implement adjusting the best value already found. It does not perform a complete search of the entire parameter space.
-The logic of it work is as follows. The current best state (parameters for max results) is taken. The first parameter is taken and all its values in the range are checked sequentially. If the best result is found, then further verification is carried out from this state. Then the next parameter is taken and all its values in the range are checked and etc.
-
-The **brute force** optimization method implement backtesting all values in strategy space of parameters.
-
-The **annealing** method is an optimization method in which the search for the maximum possible result is carried out in fewer steps https://en.wikipedia.org/wiki/Simulated_annealing
-The method works this way: first, the best state and its parameters are determined. One parameter is randomly determined, then its value from range of possible values is randomly selected. The status in this value is checked. If it is better, then it is remembered and further parameter changes are made from it.
-As the number of tests increases, the spread of parameter values decreases around those already found. That is, if at the beginning of testing the values are randomly selected from the entire range of possible parameter values, then as optimization is carried out, this spread decreases ("cools down") near current values. So in first phase of test - this method is search the most possible state around all space on the finish stage this method trying to improve found best state.
-So that the system does not get stuck in one parameter area, as it happens with the sequential method, not one random parameter changes periodically, but all at once.
-
-The **random improvements** method is the simplest. One parameter is randomly determined and then a value is randomly selected for it from the entire range of possible values. If the condition is better, then it is remembered. And then the parameters from this state are randomly changed.
-
-The **random** method - always selects random values for all parameters at once (default)
-
-
-### Upload external signals to tradingview chart
-
-Loading external buy or sell signals by timestamps from a CSV file*
-
-![](docs/Screenshot2.png)
-
-To display the signals, you need to create a pine script named 'iondvSignals' from the script bellow add it to the chart:
-```
-//©akumidv
-//@version=4
-study("iondv Signals", shorttitle="iondvSignals", overlay=true)
-strTSBuy = input("", "TSBuy")
-strTSBuy = input("", "TSSell")
-tickerName = input("", "Ticker")
-var arrTSBuy = str.split(buy_series_time, ",")
-var arrTSSell = str.split(sell_series_time, ",")
-plotchar(tickerName == syminfo.ticker and array.includes(arrTSBuy, tostring(time)) ? low : na, location = location.belowbar, color=color.green, char='▲')
-plotchar(tickerName == syminfo.ticker and array.includes(arrTSSell, tostring(time)) ? low : na, location = location.abovebar, color=color.red, char='▼')
-```
-
-After that, upload the signals from the file created accordingly the template
-```CSV
-timestamp,ticker,timeframe,signal
-1625718600000,BTCUSDT,1m,BUY
-2021-07-27T01:00:00Z,BABA,1H,SELL
-```
-
-The signals are stored in the browser, to activate them, open the properties of the created indicator named 'iondvSignals'.
-
-## Setup
-
-Install from [Chrome webstroe](https://chrome.google.com/webstore/detail/tradingview-assistant/pfbdfjaonemppanfnlmliafffahlohfg)
-
-Or manually add the latest version to chrome based browser from this repository by following the instruction below.
-
-Click on the browser's address bar, insert `chrome://extensions` and follow this link. Click on the "Developer mode" switch.
-
-The "Load unpacked" button should appear. Click on it, and in the window that opens, select the folder with the saved
-repository files (you can download them as a zip archive via the
-link https://github.com/akumidv/tradingview-assistant-chrome-extension/archive/refs/heads/main.zip).
-
-The `manifest.json` file is located in the root folder of the extension.
-
-### Update
-Unpack the new version to the same directory as the previous version (it is better to delete the files of the previous version).
-Go to the extensions tab by following the link `chrome://extensions`. Click the restart button for the extension.
-
-### Issues
-Please add issues in this repository by following [link](https://github.com/akumidv/tradingview-assistant-chrome-extension/issues).
-
-Very helpfull will be if you can attach full screenshot with tradingview page and errors. And also with open command tab in browser developer mode (please press F12 to open developer mode and click on console tab)
-
-## PS
-** The field separator for CSV files is a comma.
-
-
-## **Recommendation**
-
-If your strategy requires a large amount of testing, it is recommended to order its conversion into python and perform 
-backtesting and hyperoptimization of parameters using resources, such as Google Collab or your computer. In addition, it significantly speeds up the search for parameters (in 5-10 times per cycle) and history deep. Examples in Jupyter Notebooks in repository [trade-strategies-backtesting-optimization](https://github.com/akumidv/trade-strategies-backtesting-optimization). You can run examples in Google Collab, it's free. You would just upload files  with extension `*.ipynb` to your Google Drive and open these files.
-
-Where transfering from TradingViews scripts usually developer should solve some promblems:
-* Trading view indicators – some of them have different formulas to calculate results, for example supertrend, ta.RMA and more others. They need additional implementation and in results they calculated more slowly than if python script would use `ta-lib`.
-* Implementation of the data parsing. If the data for the crypt is mostly free, but the data of low timeframes is usually paid (for example, eodhistoricaldata). Developer need to implement an interface to them and some process to store and reuse local(cloud) stored data.
-- Difference in data for stock or forex exchanges from Tradingview. Also, for some cryptocurrency exchanges.
-- Adopt framework of backtesting (backtesting, backtrader, vectorbot, etc.) to work with strategy
-- Wrap this code for frameworks of parameter gyperspace optimization (simple example you can see in [trade-strategies-backtesting-optimization](https://github.com/akumidv/trade-strategies-backtesting-optimization)) and increase speed of backtesting with some methods.
-
-
-From my experience it demands 2-3 minutes developer time for each row of tradingview script. For example if you have 200 line strategy it would demand ~6 hours to conversion. For some complicated strategies it can deman much more.
-
-To reduce developing time you can use some my repositories: 
-* [tradingview-ta-lib](https://github.com/akumidv/tradingview-ta-lib) - Tradingview `ta` lib implementation in python (only for tradingview indecators that have different caclulatoin results with `ta-lib` or `python-ta` - early developing stage.
-* [catcher-bot](https://github.com/akumidv/catcher-bot) - Bot for screening all symbols on excahnges/exchanges and cath trade signals - early developing stage.
-
-## Contacts
-
-akumidv `[at]` yahoo.com  (Do not send errors to email please, use [github issues](https://github.com/akumidv/tradingview-assistant-chrome-extension/issues) for them)
-
-https://linkedin.com/in/akuminov
-
-https://fb.com/akuminov
-
-Regarding contacts via social networks - they are banned in Russia, so I do not answer quickly. Email is preferred way, but usually I do not have the ability to answer quickly (2-3 days delay).
-
-## Project development donate
-Cryptocurrency transfer information       
-       
-* USDT, TRX (TRC20) network        TFqv5hB3cdVHxkxhL8qjpfRMbeqMcuwzFP
-* USDT, Matic (Poligon) network:        0xe837f97420abba87bee280b6edf319b07289b513
-* USDT, ETH (ERC20) network:        0xe837f97420abba87bee280b6edf319b07289b513
-* USDT, BSC (BEP20) network:        0xe837f97420abba87bee280b6edf319b07289b513
-* USDT, Sol (Solana) network:        CuwuesyM1tyrjyJr9avDrrRqcB4rTbciao5mXYP8HkKo
-       
-Binance Pay ID for USDT, USDC, BUSD or other crypto:        240890941 (akumidv)
+1. Download the files from this Repository as a zip file, and unzip it in your local computer.
+2. Open the Chrome Browser and type chrome://extensions/
+3. Delete any related extension.
+4. 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # About
-This tool builds upon two existing Chrome Extensions for backtesting in Tradingview:
-
-[The optimizer](https://chrome.google.com/webstore/detail/the-optimiser-tradingview/emcpjechgmpcnjphefjekmdlaljbiegp)
-
-and The
-[Tradingview assistant](https://chrome.google.com/webstore/detail/tradingview-assistant/pfbdfjaonemppanfnlmliafffahlohfg).
+This tool builds upon two existing Chrome Extensions for backtesting in Tradingview: [The optimizer](https://chrome.google.com/webstore/detail/the-optimiser-tradingview/emcpjechgmpcnjphefjekmdlaljbiegp),  and The [Tradingview assistant](https://chrome.google.com/webstore/detail/tradingview-assistant/pfbdfjaonemppanfnlmliafffahlohfg).
 
 I am not certain about their history, but for the most part the codes are identical. Going over their online history, The Tradingview Assistant is older by a couple days, and has made the code open source in [Github](https://github.com/akumidv/tradingview-assistant-chrome-extension).
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ You can simply copy those files from this repository and replace them in the ori
 To install from here:
 
 1. Download the files from this Repository as a zip file, and unzip it in your local computer.
-2. Open the Chrome Browser and type chrome://extensions/
+2. Open the Chrome Browser and type "chrome://extensions/" hit Enter
 3. Delete any related extension.
-4. 
+4. Click on "Load unpacked" and browse to the folder you unzipped...Operate as normal...
+
+At each interacition of the optimization, the list of trades will be saved to your local folder. The name of each iteractoin will be appended to the list of main results, so you can post-process the data provided by the assistnat with any other you can gain from the list of trades.
+
+Please consider supporting the original developers from The optimizer and the Tradingview Assistant.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,14 @@
+let csv_download_name = '';
+
+chrome.runtime.onMessage.addListener((msg, sender, sendRes) => {
+    if (msg.message == 'donwload_button_clicked_to_background') {
+        csv_download_name = msg.download_name;
+        chrome.downloads.onDeterminingFilename.addListener(downloadListener);
+    }
+    return true;
+});
+
+function downloadListener(downloadItem, suggest) {
+    suggest({filename:csv_download_name + ".csv", conflictAction: "overwrite"});
+    chrome.downloads.onDeterminingFilename.removeListener(downloadListener);
+}

--- a/content_scripts/action.js
+++ b/content_scripts/action.js
@@ -12,6 +12,7 @@ action.saveParameters = async () => {
   Object.keys(strategyData.properties).forEach(key => {
     strategyParamsCSV += `${JSON.stringify(key)},${typeof strategyData.properties[key][0] === 'string' ? JSON.stringify(strategyData.properties[key]) : strategyData.properties[key]}\n`
   })
+  console.log('Saving strategy params to ' + strategyData.name + '.csv File!');
   file.saveAs(strategyParamsCSV, `${strategyData.name}.csv`)
 }
 
@@ -245,6 +246,7 @@ action._saveTestResults = async (testResults, testParams, isFinalTest = true) =>
   }
 
   const CSVResults = file.convertResultsToCSV(testResults)
+
   const bestResult = testResults.perfomanceSummary ? model.getBestResult(testResults) : {}
   const initBestValue = testResults.hasOwnProperty('initBestValue') ? testResults.initBestValue : null
   const propVal = {}
@@ -261,6 +263,10 @@ action._saveTestResults = async (testResults, testParams, isFinalTest = true) =>
   if (isFinalTest)
     await ui.showPopup(text)
   console.log(`All done.\n\n${bestResult && bestResult.hasOwnProperty(testParams.optParamName) ? 'The best ' + (testResults.isMaximizing ? '(max) ':'(min) ')  + testParams.optParamName + ': ' + bestResult[testParams.optParamName] : ''}`)
+  console.log('Final Results are: \n');
+  console.log(CSVResults);
+
+  // TODO
   file.saveAs(CSVResults, `${testResults.ticker}:${testResults.timeFrame}${testResults.isDeepTest ? ' deep backtesting' : ''} ${testResults.shortName} - ${testResults.cycles}_${testResults.isMaximizing ? 'max':'min'}_${testResults.optParamName}_${testResults.method}.csv`)
 }
 

--- a/content_scripts/backtest.js
+++ b/content_scripts/backtest.js
@@ -44,6 +44,8 @@ backtest.testStrategy = async (testResults, strategyData, allRangeParams) => {
   // console.log('bestValue', testResults.bestValue)
   // console.log('bestPropVal', testResults.bestPropVal)
 
+  // await tv.startNewTradesList();
+
   // Test strategy
   const optimizationState = {}
   let isEnd = false
@@ -79,6 +81,12 @@ backtest.testStrategy = async (testResults, strategyData, allRangeParams) => {
         if(optRes === null)
           isEnd = true
     }
+
+    // DEBUG
+    console.log('Trying to click List of Trades...');
+    let tradesListFileName = await tv.saveTradesList();
+    // console.log("Saved " + tradesListFileName + " as trades list CSV!");
+
     if(isEnd)
       break
     if(optRes.hasOwnProperty('data') && optRes.hasOwnProperty('bestValue') && optRes.bestValue !== null && optRes.hasOwnProperty('bestPropVal')) {
@@ -229,9 +237,15 @@ async function getResWithBestValue(res, testResults, bestValue, bestPropVal, pro
         res.isFiltered = true
       }
     }
+
+    //TODO
+    res.data['ID'] = 'A' + tv.csv_download_index.toString().padStart(5, '0');
     if(isFiltered)
       testResults.filteredSummary.push(res.data)
     else
+    // DEBUG
+      // console.log('perfomanceSummary row:\n');
+      // console.log(res.data);
       testResults.perfomanceSummary.push(res.data)
     await storage.setKeys(storage.STRATEGY_KEY_RESULTS, testResults)
 

--- a/content_scripts/file.js
+++ b/content_scripts/file.js
@@ -131,6 +131,8 @@ file.convertResultsToCSV = (testResults) => {
       headers = Object.keys(headersAll)
   }
 
+  headers.unshift('ID');
+
   let csv = headers.map(header => JSON.stringify(header)).join(',')
   csv += '\n'
   testResults.perfomanceSummary.forEach(row => {

--- a/content_scripts/tv.js
+++ b/content_scripts/tv.js
@@ -2,9 +2,11 @@ const tv = {
   reportNode: null,
   tickerTextPrev: null,
   timeFrameTextPrev: null,
-  isReportChanged: false
+  isReportChanged: false,
+  csv_download_index: 1,
 }
 
+// var csv_download_index = 1;
 
 // Inject script to get access to TradingView data on page
 const script = document.createElement('script');
@@ -18,8 +20,6 @@ document.documentElement.appendChild(scriptPlot);
 const tvPageMessageData = {}
 
 window.addEventListener('message', messageHandler)
-
-
 async function messageHandler(event) {
   const url =  window.location && window.location.origin ? window.location.origin : 'https://www.tradingview.com'
   if (!event.origin.startsWith(url) || !event.data ||
@@ -35,6 +35,56 @@ async function messageHandler(event) {
   }
 }
 
+// DEBUG
+tv.startNewTradesList = async () => {
+  tv.csv_download_index = 1;
+}
+
+tv.saveTradesList = async () => {
+  let csv_download_name = 'A' + tv.csv_download_index.toString().padStart(5, '0');
+
+  let tradesListTabButtonNodes = document.evaluate('//button[.="List of Trades"]', document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+  if (tradesListTabButtonNodes !== null) {
+    let tradesListTabButtonEl = tradesListTabButtonNodes.snapshotItem(0);
+    console.log('List of Trades tab found!');
+    tradesListTabButtonEl.click();
+    console.log('Switched to "List of Trades" tab!');
+
+    // Export data button
+    // while (true) {
+      let exportDataButtonNodes = document.evaluate("//div[@data-strategy-title]/following-sibling::div[1]/button[last()]", document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+      if (exportDataButtonNodes !== null) {
+        let exportDataButtonEl = exportDataButtonNodes.snapshotItem(0);
+        if (exportDataButtonEl !== null) {
+          console.log(exportDataButtonEl);
+          console.log('Export data button found!');
+          
+          msg = {message:"donwload_button_clicked_to_background", download_name: csv_download_name};
+          chrome.runtime.sendMessage(msg);
+          tv.csv_download_index += 1;
+
+          exportDataButtonEl.click();
+          console.log('Export data button clicked!');
+        }
+        else {
+          return SomeUndefined;
+          console.log(exportDataButtonNodes);
+          console.log('Could not find Export data button!');
+        }
+      }
+      else {
+        console.log(exportDataButtonNodes);
+          console.log('Could not find Export data button elements!');
+      }
+  
+    // }
+  }
+  else {
+    console.log('Could not find "List of Trades" tab!');
+  }
+
+  return csv_download_name;
+}
 
 tv.getStrategy = async (strategyName = null, isIndicatorSave = false) => {
   let strategyData = {}

--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,10 @@
             "run_at": "document_end"
         }
     ],
-    "permissions": ["storage", "unlimitedStorage", "activeTab"],
+    "background": {
+      "service_worker": "background.js"
+    },
+    "permissions": ["storage", "unlimitedStorage", "activeTab", "downloads"],
     "action": {
           "default_icon": {
             "16": "images/tv_assist_16.png",


### PR DESCRIPTION
A missing functionality that will be nice to include is the capacity to download the "list of trades" of each iteration of the optimization. These data can be post-processed for several reasons... in my specific case, I wish to compare temporally the drawdown (DD) of an account with numerous forex pairs. The list of trades can also be used for strategies using pyramiding for better calculation of the DD, which in TV is simply the largest DD of any single entry..but if multiple entries occur simultaneously, then the reported DD by  TV could be misleading.  With the list of trades, one can add the total DD of all open trades at any given time, and get a more accurate DD.

So we developed this functionality to download the list of trades... at each iteration of the optimization, this code will download the file, each file is given an sequential ID name, which is also attached as a column in the main list of results, so we can pair any analysis from the list of trades with the summary results returned by the TV Assistant.  

I am already using this function in my own work, but wanted to make it known here in case you want to incorporate it. I rather you have it.