### PR TITLE
Fix: Repair broken dropdown parameter functionality

### DIFF
--- a/content_scripts/page.js
+++ b/content_scripts/page.js
@@ -94,12 +94,14 @@ page.getElText = (element) => {
 page.setSelByText = async (selector, textValue) => {
   let isSet = false
   await page.waitForSelector(selector, 1000)
-  await page.waitForTimeout(15) // Some times if list quite long, TV is not filled values yet and it generate an error
+  await page.waitForTimeout(15) // Give UI time to render
   let selectorAllVal = document.querySelectorAll(selector)
   if (!selectorAllVal || !selectorAllVal.length)
     return isSet
+
   for (let optionsEl of selectorAllVal) {
-    if (optionsEl) {//&& options.innerText.startsWith(textValue)) {
+    if (optionsEl) {
+      // 1. 获取选项文本
       let itemValue = page.getElText(optionsEl)
       if (!itemValue) {
         const ariaLabel = optionsEl.getAttribute('aria-label') || optionsEl.getAttribute('data-label') || optionsEl.getAttribute('data-name')
@@ -112,17 +114,23 @@ page.setSelByText = async (selector, textValue) => {
         else if (optionsEl.dataset.label)
           itemValue = optionsEl.dataset.label
       }
+
+      // 2. 规范化对比 (小写 + 去空格)
       const normalizedItem = itemValue ? itemValue.trim().toLowerCase() : ''
       const normalizedTarget = textValue ? textValue.trim().toLowerCase() : ''
-      if (normalizedItem && normalizedTarget && (normalizedItem === normalizedTarget || normalizedItem.startsWith(normalizedTarget))) {
-        page.mouseClick(optionsEl) // optionsEl.click()
+
+      // 🔥 修复重点 1：删掉了 startsWith，只保留 === 全等
+      if (normalizedItem && normalizedTarget && normalizedItem === normalizedTarget) {
+        page.mouseClick(optionsEl)
         await page.waitForSelector(selector, 1000, true)
         isSet = true
         break
       }
+
+      // 🔥 修复重点 2：Fallback 逻辑里也删掉 startsWith
       if (!normalizedItem && optionsEl.textContent) {
         const fallback = optionsEl.textContent.trim().toLowerCase()
-        if (fallback && normalizedTarget && (fallback === normalizedTarget || fallback.startsWith(normalizedTarget))) {
+        if (fallback && normalizedTarget && fallback === normalizedTarget) {
           page.mouseClick(optionsEl)
           await page.waitForSelector(selector, 1000, true)
           isSet = true

--- a/content_scripts/selector.js
+++ b/content_scripts/selector.js
@@ -143,12 +143,12 @@ const SEL = {
   strategyTabPeriodDD: '[class^="dateRangeMenuWrapper"] button',
   strategyTabPeriodEntyreHistory: '[class^="eventWrapper"] [role="group"] > div:nth-child(5) > div[aria-checked="true"]',
 
-  strategyListOptions: 'div[role="listbox"] [role="option"]',
+  strategyListOptions: 'div[role="option"]',
   strategyDefaultElement: '#property-actions',
 
   strategyImportExport: '#iondvImportExport',
 
-  chartTicker: '#header-toolbar-symbol-search > div[class*="text-"]',
+  chartTicker: '#header-toolbar-symbol-search span[class*="symbolName-"]',
   chartTimeframeFavorite: '#header-toolbar-intervals button[data-value]',
   chartTimeframeActive: '#header-toolbar-intervals button[data-value][aria-checked="true"]',
   chartTimeframeMenuOrSingle: '#header-toolbar-intervals button[class^="menu"]',


### PR DESCRIPTION
Hi dear @akumidv ,

The dropdown selectors for strategy parameters were broken by a recent TradingView UI update.

This PR fixes:

The selector for dropdown options (strategyListOptions).

The click target in getStrategyParams to read dropdowns.

The click target in _setStrategyParamsLegacy to write to dropdowns.

The backtesting now works correctly with dropdown parameters.

A note on formatting in tv.js
You will notice a very large number of changes in tv.js. My apologies for the large "diff" – I ran Prettier on the file while I was fixing the bugs, and it reformatted the entire file.

The actual functional changes are only the small fixes inside the getStrategyParams and _setStrategyParamsLegacy functions, as described above.

If you prefer, I am happy to revert the formatting changes and submit a new PR with only the functional bug fixes. Please just let me know.

Thanks for your work on this great extension!