### PR TITLE
fix: updated chartTicker to match current TV behavior

### DIFF
--- a/content_scripts/selector.js
+++ b/content_scripts/selector.js
@@ -95,7 +95,7 @@ const SEL = {
 
   strategyImportExport: '#iondvImportExport',
 
-  chartTicker: '#header-toolbar-symbol-search > div',
+  chartTicker: '#header-toolbar-symbol-search > span',
   chartTimeframeFavorite: '#header-toolbar-intervals button[data-value]',
   chartTimeframeActive: '#header-toolbar-intervals button[data-value][aria-checked="true"]',
   chartTimeframeMenuOrSingle: '#header-toolbar-intervals button[class^="menu"]',


### PR DESCRIPTION
<img width="552" height="142" alt="image" src="https://github.com/user-attachments/assets/b6fd19d9-973e-4d71-9519-38a4e620128d" />

This fix updates the current chartTicker to use `span` instead of `div`.